### PR TITLE
fix: this name will be the one displayed in the store

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -1,6 +1,6 @@
 {
   "version": "1.0.1",
-  "name": "cozy-konnector-bank-cic",
+  "name": "CIC",
   "type": "konnector",
   "language": "node",
   "icon": "icon.png",


### PR DESCRIPTION
Wow this connector is quite clean ! Only one fix for the name in the manifest since this name is the one displayed in the store and I don't think you want cozy-konnector-bank-cic to be displayed